### PR TITLE
Windows 10 April 2018 Update SDK (17134)

### DIFF
--- a/compress/xtcompress_Desktop_2017.vcxproj
+++ b/compress/xtcompress_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{7EF1459A-D590-4C0F-B88E-B70B4D30ED85}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtcompress</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/d3d11/xtd3d11_Desktop_2017.vcxproj
+++ b/d3d11/xtd3d11_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{1B283FC1-7914-4B61-A618-0A83DAC6770A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtd3d11</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/d3d11/xtd3d11_Desktop_2017_Win10.vcxproj
+++ b/d3d11/xtd3d11_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{1B283FC1-7914-4B61-A618-0A83DAC6770A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtd3d11</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/d3d11loadtest/d3d11loadtest_Desktop_2017.vcxproj
+++ b/d3d11loadtest/d3d11loadtest_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>d3d11loadtest</RootNamespace>
     <ProjectGuid>{d55be9cb-952d-4650-856a-72ac7aa2805d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/d3d11loadtest/d3d11loadtest_Desktop_2017_Win10.vcxproj
+++ b/d3d11loadtest/d3d11loadtest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>d3d11loadtest</RootNamespace>
     <ProjectGuid>{d55be9cb-952d-4650-856a-72ac7aa2805d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/d3d12/xtd3d12_Desktop_2017_Win10.vcxproj
+++ b/d3d12/xtd3d12_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{C211AD18-3C9A-4A12-BB1A-624F58E11E76}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtd3d12</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/d3d12loadtest/d3d12loadtest_Desktop_2017_Win10.vcxproj
+++ b/d3d12loadtest/d3d12loadtest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>d3d12loadtest</RootNamespace>
     <ProjectGuid>{1253f761-7821-47bd-8185-2ff0a54a4572}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/dds/xtdds_Desktop_2017.vcxproj
+++ b/dds/xtdds_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{FE5CF2AA-CB4C-43E7-846F-A51CD26A3E87}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtdds</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/filter/xtfilter_Desktop_2017.vcxproj
+++ b/filter/xtfilter_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{3F2E8E24-F969-47F5-BA94-79CA8450DA74}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtfilter</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/fuzzloaders/fuzzloaders_Desktop_2017.vcxproj
+++ b/fuzzloaders/fuzzloaders_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{65A50BAD-23BA-426B-9D72-2BD06F31F13B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>fuzzloaders</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/hdr/xthdr_Desktop_2017.vcxproj
+++ b/hdr/xthdr_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{5CD5746E-789D-40A9-BFD2-251CE659489A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xthdr</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/tex/xttex_Desktop_2017.vcxproj
+++ b/tex/xttex_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{8395A22A-016B-4F36-9EDE-9D274980DFE9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xttex</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/tga/xttga_Desktop_2017.vcxproj
+++ b/tga/xttga_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{6E60CF04-E4E4-4FAC-B9E1-62F783FBBD78}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xttga</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/wic/xtwic_Desktop_2017.vcxproj
+++ b/wic/xtwic_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{587A57B7-656C-4BAD-A117-F2EC74594955}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtwic</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Updated VS 2017 projects to use the Windows 10 SDK (17134) which requires the VS 2017 (15.7 update)