### PR TITLE
Fix CMake problem with /Zc:templateScope on older Windows SDKs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
       foreach(t IN LISTS TEST_EXES)
-        target_compile_options(${t} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${t} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
       endforeach()
     endif()
 endif()


### PR DESCRIPTION
When building with CMake and VS 2022 Update 5 or later, I make use of ``/Zc:templateScope`` for conformance validation. This is, however, not compatible with the Windows SDK prior to the Windows SDK (22000) build.