### PR TITLE
Update fuzz test

### DIFF
--- a/fuzzloaders/CMakeLists.txt
+++ b/fuzzloaders/CMakeLists.txt
@@ -34,6 +34,10 @@ endif()
 
 add_executable(${PROJECT_NAME} fuzzloaders.cpp ../../Texconv/PortablePixMap.cpp)
 
+if(BUILD_FUZZING)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE FUZZING_BUILD_MODE)
+endif()
+
 if(MINGW OR (NOT WIN32))
     find_package(directxmath CONFIG REQUIRED)
     find_package(directx-headers CONFIG REQUIRED)
@@ -115,8 +119,9 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (BUILD_FUZZING AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.32)
-        target_compile_options(${PROJECT_NAME} PRIVATE /fsanitize=address /fsanitize-coverage=inline-8bit-counters /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div)
+        target_compile_options(${PROJECT_NAME} PRIVATE /fsanitize=fuzzer /fsanitize=address /fsanitize-coverage=inline-8bit-counters /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div)
         target_link_libraries(${PROJECT_NAME} PRIVATE sancov.lib)
+        target_link_options(${PROJECT_NAME} PRIVATE /IGNORE:4291)
     endif()
 endif()
 

--- a/fuzzloaders/fuzzloaders.cpp
+++ b/fuzzloaders/fuzzloaders.cpp
@@ -290,6 +290,8 @@ HRESULT __cdecl LoadFromPortablePixMapHDR(
 //--------------------------------------------------------------------------------------
 // Entry-point
 //--------------------------------------------------------------------------------------
+#ifndef FUZZING_BUILD_MODE
+
 #ifdef _PREFAST_
 #pragma prefast(disable : 28198, "Command-line tool, frees all memory on exit")
 #endif
@@ -658,6 +660,9 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 }
 
 
+#else // FUZZING_BUILD_MODE
+
+
 //--------------------------------------------------------------------------------------
 // Libfuzzer entry-point
 //--------------------------------------------------------------------------------------
@@ -703,3 +708,5 @@ extern "C" __declspec(dllexport) int LLVMFuzzerTestOneInput(const uint8_t *data,
     return 0;
 }
 #endif
+
+#endif // FUZZING_BUILD_MODE


### PR DESCRIPTION
For libfuzzer, the program should not have a `main` and needs to use `-fsanitize=fuzzer`.