### PR TITLE
Remove internal tests when building as a DLL

### DIFF
--- a/tex/convert.cpp
+++ b/tex/convert.cpp
@@ -785,7 +785,8 @@ namespace
 //-------------------------------------------------------------------------------------
 
 extern HRESULT SaveScratchImage(_In_z_ const wchar_t* szFile, _In_ DirectX::DDS_FLAGS flags, _In_ const ScratchImage& image);
-extern HRESULT CopyViaLoadStoreScanline(const Image& srcImage, ScratchImage& image);
+
+#ifndef DIRECTX_TEX_IMPORT
 
 //-------------------------------------------------------------------------------------
 // Convert (internalA)
@@ -1017,6 +1018,8 @@ static const TestPixels s_TestPartialTypeless[] =
 
 //-------------------------------------------------------------------------------------
 // Convert (internalB)
+extern HRESULT CopyViaLoadStoreScanline(const Image& srcImage, ScratchImage& image);
+
 bool TEXTest::Test05B()
 {
     using namespace DirectX::Internal;
@@ -1299,7 +1302,6 @@ bool TEXTest::Test05C()
 
     return success;
 }
-
 
 
 //-------------------------------------------------------------------------------------
@@ -2813,6 +2815,8 @@ bool TEXTest::Test05D()
 // TODO: ConvertToR32G32B32A32, ConvertFromR32G32B32A32 (x3)
 // ConvertToR16G16B16A16, ConvertFromR16G16B16A16
 
+#endif // !DIRECTX_TEX_IMPORT
+
 
 //-------------------------------------------------------------------------------------
 // Convert(Ex)
@@ -3204,6 +3208,7 @@ bool TEXTest::Test06()
 
 // TODO - TEX_FILTER_MIRROR / TEX_FILTER_WRAP (requires TEX_FILTER_LINEAR or TEX_FILTER_CUBIC)
 
+#ifndef DIRECTX_TEX_IMPORT
                 //--- WIC vs. non-WIC convert -----------------------------------------
                 WICPixelFormatGUID pfGUID, targetGUID;
                 if ( Internal::DXGIToWIC( metadata.format, pfGUID )
@@ -3459,6 +3464,7 @@ bool TEXTest::Test06()
 #endif
                     }
                 }
+#endif // !DIRECTX_TEX_IMPORT
 
                 //--- SRGB convert ----------------------------------------------------
                 if (IsSRGB(tformat) || IsSRGB(metadata.format))

--- a/tex/directxtest.cpp
+++ b/tex/directxtest.cpp
@@ -37,10 +37,12 @@ TestInfo g_Tests[] =
     { "TransformImage", TEXTest::Test17 },
     { "IsAlphaAllOpaque", TEXTest::Test14 },
     { "FlipRotate", TEXTest::Test04 },
+#ifndef DIRECTX_TEX_IMPORT
     { "Convert (internalA)", TEXTest::Test05 },
     { "Convert (internalB)", TEXTest::Test05B },
     { "Convert (internalC)", TEXTest::Test05C },
     { "Convert (internalD)", TEXTest::Test05D },
+#endif
     { "Convert", TEXTest::Test06 },
 #ifndef BUILD_BVT_ONLY
     { "ConvertToSinglePlane", TEXTest::Test15 },

--- a/tex/testutils.cpp
+++ b/tex/testutils.cpp
@@ -157,6 +157,8 @@ HRESULT SaveScratchImage( _In_z_ const wchar_t* szFile, _In_ DirectX::DDS_FLAGS 
 
 
 //-------------------------------------------------------------------------------------
+#ifndef DIRECTX_TEX_IMPORT
+
 HRESULT CopyViaLoadStoreScanline( const Image& srcImage, ScratchImage& image )
 {
     using namespace DirectX::Internal;
@@ -217,6 +219,8 @@ HRESULT CopyViaLoadStoreScanline( const Image& srcImage, ScratchImage& image )
 
     return S_OK;
 }
+
+#endif // !DIRECTX_TEX_IMPORT
 
 
 //-------------------------------------------------------------------------------------


### PR DESCRIPTION
When building with CMake using `BUILD_SHARED_LIBS`, some of the tests fail to link since they use internal functions only available in the static C++ library. This updates the tests to build without those when needed.